### PR TITLE
No star bellied sneetches

### DIFF
--- a/src/commandList.ts
+++ b/src/commandList.ts
@@ -19,7 +19,7 @@ import {
   DowCommand,
 } from './tendies';
 import { CovidCommand, CovidWiCommand, VaccineWiCommand } from './covid/covid-command';
-import { NiceReaction, ChulasRecation, GroupReaction } from './reactions';
+import { NiceReaction, ChulasRecation } from './reactions';
 import { DevNullCommand } from './dev_null/dev-null-command';
 import { FlavorForecastCommand, FlavorOfTheDayCommand } from './kopps';
 import { TrompoCommand, RocketManCommand, TweetCommand } from './tweet';
@@ -47,7 +47,6 @@ export const commandList: ICommand[] = [
   VaccineWiCommand,
   NiceReaction,
   ChulasRecation,
-  GroupReaction,
   DevNullCommand,
   DrawMemeCommand,
   FlavorForecastCommand,

--- a/src/reactions/index.ts
+++ b/src/reactions/index.ts
@@ -1,1 +1,1 @@
-export { NiceReaction, ChulasRecation, GroupReaction } from './react';
+export { NiceReaction, ChulasRecation } from './react';

--- a/src/reactions/react.ts
+++ b/src/reactions/react.ts
@@ -31,12 +31,12 @@ export const GroupReaction: ICommand = {
   trigger: (msg: Message) => msg.channel.id === '619704904696594493',
   command: async (msg: Message) => {
     const groupA = await msg.guild.roles.fetch('849368883689291776', false, true);
-    if (groupA && groupA.members.some((member) => member.user.id === msg.author.id)) {
-      await msg.react('🅰️');
+    if (groupA.members.some((member) => member.user.id === msg.author.id)) {
+      await msg.react('A');
     } else {
       const groupB = await msg.guild.roles.fetch('849368974083883038', false, true);
-      if (groupB && groupB.members.some((member) => member.user.id === msg.author.id)) {
-        await msg.react('🅱️');
+      if (groupB.members.some((member) => member.user.id === msg.author.id)) {
+        await msg.react('B');
       }
     }
   },

--- a/src/reactions/react.ts
+++ b/src/reactions/react.ts
@@ -23,21 +23,3 @@ export const ChulasRecation: ICommand = {
     await msg.react('🤦‍♂️');
   },
 };
-
-export const GroupReaction: ICommand = {
-  name: 'Group reaction',
-  helpDescription: '',
-  showInHelp: false,
-  trigger: (msg: Message) => msg.channel.id === '619704904696594493',
-  command: async (msg: Message) => {
-    const groupA = await msg.guild.roles.fetch('849368883689291776', false, true);
-    if (groupA.members.some((member) => member.user.id === msg.author.id)) {
-      await msg.react('A');
-    } else {
-      const groupB = await msg.guild.roles.fetch('849368974083883038', false, true);
-      if (groupB.members.some((member) => member.user.id === msg.author.id)) {
-        await msg.react('B');
-      }
-    }
-  },
-};


### PR DESCRIPTION
As foretold in the parable of the [Star-Bellied Sneetches](https://seuss.fandom.com/wiki/The_Sneetches), making obvious comparisons between two sub-groups will inevitably cause division in the group. This commit reverts #169, #170, and #171 to ensure that such divisions remain a verbal meme and not a visible marker in Discord.